### PR TITLE
Add SEO metadata for project pages

### DIFF
--- a/pages/project/cake.vue
+++ b/pages/project/cake.vue
@@ -6,6 +6,21 @@ import { ProjectArticleNames } from '~/lib/constants/projects/project-article-en
 const projectInfo = computed(() =>
     PROJECTS_LIST.find(project => project.title === ProjectArticleNames.CAKE),
 );
+
+const seoTitle = computed(() => projectInfo.value
+    ? `Project Spotlight: ${projectInfo.value.title}`
+    : 'Project Spotlight',
+);
+const seoDescription = computed(() => projectInfo.value?.description);
+
+useSeoMeta(() => ({
+    title: seoTitle.value,
+    ogTitle: seoTitle.value,
+    twitterTitle: seoTitle.value,
+    description: seoDescription.value,
+    ogDescription: seoDescription.value,
+    twitterDescription: seoDescription.value,
+}));
 </script>
 
 <template>

--- a/pages/project/cake.vue
+++ b/pages/project/cake.vue
@@ -34,6 +34,7 @@ useSeoMeta(() => ({
 
         <content-doc
             class="prose prose-slate dark:prose-invert"
+            :head="false"
             path="/project-spotlights/cake"
         />
     </div>

--- a/pages/project/ge-skiller.vue
+++ b/pages/project/ge-skiller.vue
@@ -6,6 +6,21 @@ import { ProjectArticleNames } from '~/lib/constants/projects/project-article-en
 const projectInfo = computed(() =>
     PROJECTS_LIST.find(project => project.title === ProjectArticleNames.GE_SKILLER),
 );
+
+const seoTitle = computed(() => projectInfo.value
+    ? `Project Spotlight: ${projectInfo.value.title}`
+    : 'Project Spotlight',
+);
+const seoDescription = computed(() => projectInfo.value?.description);
+
+useSeoMeta(() => ({
+    title: seoTitle.value,
+    ogTitle: seoTitle.value,
+    twitterTitle: seoTitle.value,
+    description: seoDescription.value,
+    ogDescription: seoDescription.value,
+    twitterDescription: seoDescription.value,
+}));
 </script>
 
 <template>

--- a/pages/project/ge-skiller.vue
+++ b/pages/project/ge-skiller.vue
@@ -34,6 +34,7 @@ useSeoMeta(() => ({
 
         <content-doc
             class="prose prose-slate dark:prose-invert mx-auto mb-6 p-6 lg:px-0"
+            :head="false"
             path="/project-spotlights/ge-skiller/ge-skiller-1"
         />
 
@@ -48,6 +49,7 @@ useSeoMeta(() => ({
 
         <content-doc
             class="prose prose-slate dark:prose-invert mx-auto mb-6 p-6 lg:px-0"
+            :head="false"
             path="/project-spotlights/ge-skiller/ge-skiller-2"
         />
 
@@ -62,6 +64,7 @@ useSeoMeta(() => ({
 
         <content-doc
             class="prose prose-slate dark:prose-invert mx-auto mb-6 p-6 lg:px-0"
+            :head="false"
             path="/project-spotlights/ge-skiller/ge-skiller-3"
         />
     </div>

--- a/pages/project/jaiden-dot-dev.vue
+++ b/pages/project/jaiden-dot-dev.vue
@@ -34,6 +34,7 @@ useSeoMeta(() => ({
 
         <content-doc
             class="size-for-all-screens"
+            :head="false"
             path="/project-spotlights/jaiden-dot-dev"
         />
     </div>

--- a/pages/project/jaiden-dot-dev.vue
+++ b/pages/project/jaiden-dot-dev.vue
@@ -6,6 +6,21 @@ import { ProjectArticleNames } from '~/lib/constants/projects/project-article-en
 const projectInfo = computed(() =>
     PROJECTS_LIST.find(project => project.title === ProjectArticleNames.JAIDEN_DOT_DEV),
 );
+
+const seoTitle = computed(() => projectInfo.value
+    ? `Project Spotlight: ${projectInfo.value.title}`
+    : 'Project Spotlight',
+);
+const seoDescription = computed(() => projectInfo.value?.description);
+
+useSeoMeta(() => ({
+    title: seoTitle.value,
+    ogTitle: seoTitle.value,
+    twitterTitle: seoTitle.value,
+    description: seoDescription.value,
+    ogDescription: seoDescription.value,
+    twitterDescription: seoDescription.value,
+}));
 </script>
 
 <template>

--- a/pages/project/self-aware-grid.vue
+++ b/pages/project/self-aware-grid.vue
@@ -50,6 +50,7 @@ onMounted(async () => {
 
         <content-doc
             class="prose prose-slate dark:prose-invert mx-auto mb-6 p-6 lg:px-0"
+            :head="false"
             path="/project-spotlights/self-aware-grid"
         />
     </div>

--- a/pages/project/self-aware-grid.vue
+++ b/pages/project/self-aware-grid.vue
@@ -9,6 +9,21 @@ const projectInfo = computed(() =>
     PROJECTS_LIST.find(project => project.title === ProjectArticleNames.SELF_AWARE_GRID),
 );
 
+const seoTitle = computed(() => projectInfo.value
+    ? `Project Spotlight: ${projectInfo.value.title}`
+    : 'Project Spotlight',
+);
+const seoDescription = computed(() => projectInfo.value?.description);
+
+useSeoMeta(() => ({
+    title: seoTitle.value,
+    ogTitle: seoTitle.value,
+    twitterTitle: seoTitle.value,
+    description: seoDescription.value,
+    ogDescription: seoDescription.value,
+    twitterDescription: seoDescription.value,
+}));
+
 function highlightCodeBlocks(): void {
     document.querySelectorAll('pre code').forEach((block) => {
         if (block instanceof HTMLElement) {


### PR DESCRIPTION
## Summary
- add dynamic SEO meta tags for each project article page
- include social titles and descriptions based on project data

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b1aa94f98832db7f80017217162f5)