### PR TITLE
Fix GE Skiller share metadata

### DIFF
--- a/pages/project/ge-skiller.vue
+++ b/pages/project/ge-skiller.vue
@@ -6,6 +6,12 @@ import { ProjectArticleNames } from '~/lib/constants/projects/project-article-en
 const projectInfo = computed(() =>
     PROJECTS_LIST.find(project => project.title === ProjectArticleNames.GE_SKILLER),
 );
+
+useSeoMeta(() => ({
+    title: projectInfo.value
+        ? `Project Spotlight: ${projectInfo.value.title}`
+        : 'Project Spotlight',
+}));
 </script>
 
 <template>
@@ -19,6 +25,7 @@ const projectInfo = computed(() =>
 
         <content-doc
             class="prose prose-slate dark:prose-invert mx-auto mb-6 p-6 lg:px-0"
+            :head="false"
             path="/project-spotlights/ge-skiller/ge-skiller-1"
         />
 
@@ -33,6 +40,7 @@ const projectInfo = computed(() =>
 
         <content-doc
             class="prose prose-slate dark:prose-invert mx-auto mb-6 p-6 lg:px-0"
+            :head="false"
             path="/project-spotlights/ge-skiller/ge-skiller-2"
         />
 
@@ -47,6 +55,7 @@ const projectInfo = computed(() =>
 
         <content-doc
             class="prose prose-slate dark:prose-invert mx-auto mb-6 p-6 lg:px-0"
+            :head="false"
             path="/project-spotlights/ge-skiller/ge-skiller-3"
         />
     </div>


### PR DESCRIPTION
## Summary
- prevent the GE Skiller article content sections from overriding the page head metadata
- set an explicit SEO title for the GE Skiller page so shares no longer show the "Ge Skiller 3" suffix

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d7267b228832d96efaa26738a3479)