### PR TITLE
Update GE Skiller article date header

### DIFF
--- a/content/project-spotlights/ge-skiller/ge-skiller-3.md
+++ b/content/project-spotlights/ge-skiller/ge-skiller-3.md
@@ -182,6 +182,6 @@ I'm going to miss you, Hayden. Rest easy, you big dumb bitch. I love you, man.
 
 ## Thursday, December 11, 2025 at 10:17am
 
-On the morning Haydem was scheduled to be taken off life support, for the first time since this ordeal began, Hayden tracked movement with his eyes and gsve his nurse a thumbs-up in response to her. Mikayla rushed to the hospital to hopefully greet him and be there for him, but as she arrived, Hayden's vitals began crashing and he suffered a brain hemorrhage which then claimed his life.
+On the morning Hayden was scheduled to be taken off life support, for the first time since this ordeal began, Hayden tracked movement with his eyes and gsve his nurse a thumbs-up in response to her. Mikayla rushed to the hospital to hopefully greet him and be there for him, but as she arrived, Hayden's vitals began crashing and he suffered a brain hemorrhage which then claimed his life.
 
 Hayden will be missed more dearly than words can say. The world is a little more dull without him here. Miss you buddy. I always will.

--- a/content/project-spotlights/ge-skiller/ge-skiller-3.md
+++ b/content/project-spotlights/ge-skiller/ge-skiller-3.md
@@ -180,7 +180,7 @@ I'm going to miss you, Hayden. Rest easy, you big dumb bitch. I love you, man.
 
 ![Hayden and his mom](img/ge-skiller-article-images/img-11.jpg)
 
-## Thursday, December 11, 2025 at 10:17am
+## July 15, 1996 — Thursday, December 11, 2025 at 10:17am
 
 On the morning Hayden was scheduled to be taken off life support, for the first time since this ordeal began, Hayden tracked movement with his eyes and gsve his nurse a thumbs-up in response to her. Mikayla rushed to the hospital to hopefully greet him and be there for him, but as she arrived, Hayden's vitals began crashing and he suffered a brain hemorrhage which then claimed his life.
 

--- a/content/project-spotlights/ge-skiller/ge-skiller-3.md
+++ b/content/project-spotlights/ge-skiller/ge-skiller-3.md
@@ -180,7 +180,7 @@ I'm going to miss you, Hayden. Rest easy, you big dumb bitch. I love you, man.
 
 ![Hayden and his mom](img/ge-skiller-article-images/img-11.jpg)
 
-## Saturday, December 20, 2025
+## Thursday, December 11, 2025 at 10:17am
 
 On the morning Haydem was scheduled to be taken off life support, for the first time since this ordeal began, Hayden tracked movement with his eyes and gsve his nurse a thumbs-up in response to her. Mikayla rushed to the hospital to hopefully greet him and be there for him, but as she arrived, Hayden's vitals began crashing and he suffered a brain hemorrhage which then claimed his life.
 


### PR DESCRIPTION
## Summary
- update the final section header date/time in the GE Skiller article to December 11, 2025 at 10:17am

## Testing
- not run (not needed)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694737d0879c832dbaaa342b974abc6a)