### PR TITLE
Move custom sites link from header to hero as outline button

### DIFF
--- a/components/global/app-header.vue
+++ b/components/global/app-header.vue
@@ -14,13 +14,6 @@ const { open } = useContactDialog();
                 </h1>
             </nuxt-link>
 
-            <nuxt-link
-                to="/pricing"
-                class="text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
-            >
-                Custom sites
-            </nuxt-link>
-
             <tooltip-provider :delay-duration="432">
                 <tooltip>
                     <tooltip-trigger as-child>

--- a/components/homepage/hero-text.vue
+++ b/components/homepage/hero-text.vue
@@ -41,21 +41,32 @@ onMounted(() => {
                 When I'm not coding, I love learning about ancient history, spirituality, and consciousness.
             </p>
 
-            <div :class="`flex gap-6 justify-center transition ease-in-out ${animateButtonGroup} 2xl:justify-start`">
-                <Button
-                    class="bg-brand-blue text-lg transition-colors hover:bg-brand-blue-darker dark:bg-brand-blue-darker dark:text-brand-blue-foreground dark:hover:bg-brand-blue md:backlight"
-                    type="button"
-                    @click="open"
-                >
-                    Get in touch
-                </Button>
+            <div :class="`flex flex-col gap-6 items-center transition ease-in-out ${animateButtonGroup} 2xl:items-start`">
+                <div class="flex gap-6 justify-center 2xl:justify-start">
+                    <Button
+                        class="bg-brand-blue text-lg transition-colors hover:bg-brand-blue-darker dark:bg-brand-blue-darker dark:text-brand-blue-foreground dark:hover:bg-brand-blue md:backlight"
+                        type="button"
+                        @click="open"
+                    >
+                        Get in touch
+                    </Button>
+                    <Button
+                        as-child
+                        class="text-lg"
+                        variant="secondary"
+                    >
+                        <NuxtLink to="/resume">
+                            Résumé
+                        </NuxtLink>
+                    </Button>
+                </div>
                 <Button
                     as-child
                     class="text-lg"
-                    variant="secondary"
+                    variant="outline"
                 >
-                    <NuxtLink to="/resume">
-                        Résumé
+                    <NuxtLink to="/pricing">
+                        Custom sites
                     </NuxtLink>
                 </Button>
             </div>


### PR DESCRIPTION
## Summary

Moves the "Custom sites" link out of the site header and into the homepage hero as a third call-to-action button.

## Changes

- **`components/global/app-header.vue`** — Removed the "Custom sites" nav link from the header.
- **`components/homepage/hero-text.vue`** — Added a third "Custom sites" button beneath the existing "Get in touch" / "Résumé" buttons, using the `outline` variant. The two original buttons stay on one row with the new button stacked underneath.
- **`components/global/app-footer.vue`** — Unchanged; the footer "Custom sites" link remains as requested.

All links continue to point to `/pricing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LDFdDyHgVoyGEyBiWDzdLE)_