### PR TITLE
Constrain article header and Built With section to the reading column

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -39,6 +39,12 @@
     .size-for-all-screens {
         @apply max-w-7xl mx-auto;
     }
+
+    /* Matches the reading-column width of `.prose` content so article
+       headers and sub-sections line up with the article body. */
+    .article-column-width {
+        @apply max-w-[65ch] mx-auto;
+    }
 }
 
 @layer base {

--- a/components/project-showcase/project-showcase-title-area.vue
+++ b/components/project-showcase/project-showcase-title-area.vue
@@ -61,7 +61,7 @@ function toggleSpeech() {
 </script>
 
 <template>
-    <div class="size-for-all-screens flex flex-col gap-3 p-6 lg:px-0">
+    <div class="article-column-width flex flex-col gap-3 p-6 lg:px-0">
         <!-- Related links. -->
         <div class="flex gap-2 justify-end">
             <a

--- a/pages/project/jaiden-dot-dev.vue
+++ b/pages/project/jaiden-dot-dev.vue
@@ -61,14 +61,14 @@ const technologies = [
         />
 
         <div class="bg-muted py-12">
-            <div class="size-for-all-screens px-6 lg:px-0">
+            <div class="article-column-width px-6 lg:px-0">
                 <h2 class="text-2xl font-semibold mb-2">
                     Built With
                 </h2>
                 <p class="text-muted-foreground mb-8">
                     The tools and libraries that power jaiden.dev.
                 </p>
-                <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+                <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                     <div
                         v-for="tech in technologies"
                         :key="tech.name"


### PR DESCRIPTION
## Summary
- Article header (title, subtitle, tags, buttons, hero image) previously used the page-wide `size-for-all-screens` (`max-w-7xl`) container, while the article body below it uses Tailwind Typography's `prose` (`max-w-65ch`). At tablet widths this made the header span the full width of the page while the article content stayed narrow.
- Added a new `.article-column-width` utility (`max-w-[65ch] mx-auto`) matching the `prose` reading column, and applied it to the shared `project-showcase-title-area.vue` header component.
- Applied the same fix to the jaiden.dev "Built With" section, and reduced its grid from 4 columns down to 2 at the `lg` breakpoint since the section is now constrained to the narrower reading column.

## Test plan
- [x] Ran the dev server locally and screenshotted `/project/jaiden-dot-dev` at 820px and 1024px viewport widths — header, hero image, and Built With section now align to the same column width as the article body below.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EDUQMQzvTAu3LF337YJStJ)_